### PR TITLE
线性方程组去相关

### DIFF
--- a/source/Trilateration.cpp
+++ b/source/Trilateration.cpp
@@ -20,30 +20,26 @@ bool Trilateration::CalculateLocation2d(const PosAndDistance2dVec& beacons, Pos2
     
     // Define the matrix that we are going to use
     size_t count = beacons.size();
-    size_t rows = count * (count - 1) / 2;
+    size_t rows = count -1;
     Eigen::MatrixXd m(rows, 2);
     Eigen::VectorXd b(rows);
     
     // Fill in matrix according to the equations
-    size_t row = 0;
+   
     double x1, x2, y1, y2, r1, r2;
     PosAndDistance2d beacon1, beacon2;
-    for (size_t i=0; i<count; ++i) {
-        beacon1 = beacons[i];
-        for (size_t j=i+1; j<count; ++j) {
-            beacon2 = beacons[j];
-            
-            x1 = beacon1.m_pos(0), y1 = beacon1.m_pos(1);
-            x2 = beacon2.m_pos(0), y2 = beacon2.m_pos(1);
-            r1 = beacon1.m_distance;
-            r2 = beacon2.m_distance;
-            m(row, 0) = x1 - x2;
-            m(row, 1) = y1 - y2;
-            b(row) = ((pow(x1, 2)-pow(x2, 2)) +
-                      (pow(y1, 2)-pow(y2, 2)) -
-                      (pow(r1, 2) - pow(r2, 2))) / 2;
-            row++;
-        }
+	beacon2 = beacons[count -1];
+    for (size_t i=0; i<rows; ++i) {
+        beacon1 = beacons[i];             
+        x1 = beacon1.m_pos(0), y1 = beacon1.m_pos(1);
+        x2 = beacon2.m_pos(0), y2 = beacon2.m_pos(1);
+        r1 = beacon1.m_distance;
+        r2 = beacon2.m_distance;
+        m(i, 0) = x1 - x2;
+        m(i, 1) = y1 - y2;
+        b(i) = ((pow(x1, 2)-pow(x2, 2)) +
+                    (pow(y1, 2)-pow(y2, 2)) -
+                    (pow(r1, 2) - pow(r2, 2))) / 2;      
     }
     
     // Then calculate to solve the equations, using the least square solution
@@ -61,32 +57,27 @@ bool Trilateration::CalculateLocation3d(const PosAndDistance3dVec &beacons, Pos3
     
     // Define the matrix that we are going to use
     size_t count = beacons.size();
-    size_t rows = count * (count - 1) / 2;
+    size_t rows = count -1;
     Eigen::MatrixXd m(rows, 3);
     Eigen::VectorXd b(rows);
     
-    // Fill in matrix according to the equations
-    size_t row = 0;
+    // Fill in matrix according to the equations   
     double x1, x2, y1, y2, z1, z2, r1, r2;
     PosAndDistance3d beacon1, beacon2;
-    for (size_t i=0; i<count; ++i) {
-        beacon1 = beacons[i];
-        for (size_t j=i+1; j<count; ++j) {
-            beacon2 = beacons[j];
-            
-            x1 = beacon1.m_pos(0), y1 = beacon1.m_pos(1), z1 = beacon1.m_pos(2);
-            x2 = beacon2.m_pos(0), y2 = beacon2.m_pos(1), z2 = beacon2.m_pos(2);
-            r1 = beacon1.m_distance;
-            r2 = beacon2.m_distance;
-            m(row, 0) = x1 - x2;
-            m(row, 1) = y1 - y2;
-            m(row, 2) = z1 - z2;
-            b(row) = ((pow(x1, 2)-pow(x2, 2)) +
-                      (pow(y1, 2)-pow(y2, 2)) +
-                      (pow(z1, 2)-pow(z2, 2)) -
-                      (pow(r1, 2) - pow(r2, 2))) / 2;
-            row++;
-        }
+	beacon2 = beacons[count -1];
+    for (size_t i=0; i<count-1; ++i) {
+        beacon1 = beacons[i];            
+        x1 = beacon1.m_pos(0), y1 = beacon1.m_pos(1), z1 = beacon1.m_pos(2);
+        x2 = beacon2.m_pos(0), y2 = beacon2.m_pos(1), z2 = beacon2.m_pos(2);
+        r1 = beacon1.m_distance;
+        r2 = beacon2.m_distance;
+        m(i, 0) = x1 - x2;
+        m(i, 1) = y1 - y2;
+        m(i, 2) = z1 - z2;
+        b(i) = ((pow(x1, 2)-pow(x2, 2)) +
+                    (pow(y1, 2)-pow(y2, 2)) +
+                    (pow(z1, 2)-pow(z2, 2)) -
+                    (pow(r1, 2) - pow(r2, 2))) / 2;          
     }
     
     // Then calculate to solve the equations, using the least square solution


### PR DESCRIPTION
原来的线性化方法：N个距离方程(N个beacon)产生（N-1）*N/2列的线性方程组。
修改后：N个距离方程(N个beacon)产生（N-1）列的线性方程组。
修改原因：原来的方式产生的方程组是相关的